### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Install Ruby"
-        # v1.117.0
-        uses: ruby/setup-ruby@3068fa83f9cbd7ae106cac45483635a2f3a195c9
+        # v1.172.0
+        uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: "Install mdl"
         run: gem install mdl

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - name: Install shellcheck on Ubuntu
         run: |
           sudo apt update


### PR DESCRIPTION
Update actions/checkout to v4.1.1, moving away from the deprecated node 12.

Update ruby/setup-ruby to v1.172.0.